### PR TITLE
Add 2s delay after reset to identify MiscJunkDevice

### DIFF
--- a/timer/src/org/jeffpiazza/derby/devices/MiscJunkDevice.java
+++ b/timer/src/org/jeffpiazza/derby/devices/MiscJunkDevice.java
@@ -78,7 +78,10 @@ public class MiscJunkDevice extends TimerDeviceCommon {
                                    /* dtr */ false)) {
       return false;
     }
-
+    // We just reset the timer, give it 2s to startup
+    try {
+       Thread.sleep(2000); // ms.
+    } catch (Exception exc) { }
     portWrapper.write(READ_VERSION);
     long deadline = System.currentTimeMillis() + 500;
     String s;


### PR DESCRIPTION
Jeff,

This speeds up detection of the MiscJunkDevice timer and fixes the bug where if you specify MiscJunkDevice on the command line it fails to detect it.

Right before running device detection, the USB port is reset which causes the Arduino to reset.  We need to wait for the Arduino to initialize before testing for responses.

Thanks,
Mike