### PR TITLE
Support iOS Cameras

### DIFF
--- a/website/js/checkin.js
+++ b/website/js/checkin.js
@@ -307,7 +307,7 @@ function arm_webcam_dialog() {
     if (!loaded) {
       disable_preview('You may have to enable Flash, or give permission to use your webcam.');
     }
-  }, 2000);
+  }, 5000);
 }
 
 // For #photo_drop form:
@@ -338,6 +338,17 @@ Dropzone.options.photoDrop = {
 
 
 function switch_camera_modal() {
+  var i = 0;
+
+  navigator.mediaDevices.enumerateDevices()
+  .then(function(devices) {
+    devices.forEach(function(device) {
+      if( device.kind=== "videoinput") {
+        g_cameras[i]= device.deviceId;
+        i++;
+      }
+    });
+  });
   g_cameraIndex++;
   if ( g_cameraIndex >= g_cameras.length ) {
     g_cameraIndex = 0;
@@ -352,7 +363,7 @@ function switch_camera_modal() {
 	  crop_width: g_width,
 	  crop_height: g_height,
 	  constraints: {
-		  deviceId: g_cameras[g_cameraIndex]
+		  deviceId: {exact: g_cameras[g_cameraIndex]}
 	  }
   });
   Webcam.attach('#preview');

--- a/website/js/checkin.js
+++ b/website/js/checkin.js
@@ -339,7 +339,6 @@ Dropzone.options.photoDrop = {
 
 function switch_camera_modal() {
   var i = 0;
-
   navigator.mediaDevices.enumerateDevices()
   .then(function(devices) {
     devices.forEach(function(device) {
@@ -395,7 +394,6 @@ function show_photo_modal(racerid, repo) {
   }
 
   var i = 0;
-
   navigator.mediaDevices.enumerateDevices()
   .then(function(devices) {
     devices.forEach(function(device) {
@@ -415,7 +413,7 @@ function show_photo_modal(racerid, repo) {
 	  crop_width: g_width,
 	  crop_height: g_height,
 	  constraints: {
-		  deviceId: g_cameras[g_cameraIndex]
+		  deviceId: {exact: g_cameras[g_cameraIndex]}
 	  }
   });
   Webcam.attach('#preview');
@@ -439,7 +437,7 @@ window.addEventListener('orientationchange', function() {
 	  crop_width: g_width,
 	  crop_height: g_height,
 	  constraints: {
-		  deviceId: g_cameras[g_cameraIndex]
+		  deviceId: {exact: g_cameras[g_cameraIndex]}
 	  }
   });
   Webcam.attach('#preview');

--- a/website/js/webcam.js
+++ b/website/js/webcam.js
@@ -1,9 +1,9 @@
-// WebcamJS v1.0.25
+// WebcamJS v1.0.26
 // Webcam library for capturing JPEG/PNG images in JavaScript
 // Attempts getUserMedia, falls back to Flash
 // Author: Joseph Huckaby: http://github.com/jhuckaby
 // Based on JPEGCam: http://code.google.com/p/jpegcam/
-// Copyright (c) 2012 - 2017 Joseph Huckaby
+// Copyright (c) 2012 - 2019 Joseph Huckaby
 // Licensed under the MIT License
 
 (function(window) {
@@ -34,7 +34,7 @@ FlashError.prototype = new IntermediateInheritor();
 WebcamError.prototype = new IntermediateInheritor();
 
 var Webcam = {
-	version: '1.0.25',
+	version: '1.0.26',
 	
 	// globals
 	protocol: location.protocol.match(/https/i) ? 'https' : 'http',
@@ -91,10 +91,6 @@ var Webcam = {
 		
 		window.URL = window.URL || window.webkitURL || window.mozURL || window.msURL;
 		this.userMedia = this.userMedia && !!this.mediaDevices && !!window.URL;
-		
-		if (this.iOS) {
-			this.userMedia = null;
-		}
 		
 		// Older versions of firefox (< 21) apparently claim support but user media does not actually work
 		if (navigator.userAgent.match(/Firefox\D+(\d+)/)) {
@@ -274,6 +270,7 @@ var Webcam = {
 			// setup webcam video container
 			var video = document.createElement('video');
 			video.setAttribute('autoplay', 'autoplay');
+			video.setAttribute('playsinline', 'playsinline');
 			video.style.width = '' + this.params.dest_width + 'px';
 			video.style.height = '' + this.params.dest_height + 'px';
 			


### PR DESCRIPTION
This pull request enables an iOS device to take racer/car photos.  

1) It upgrades webcamJS to the latest version which supports iOS
2) It fixes the switch camera functionality on iOS as safari requires the camera to be open prior to enumerating devices.  It thus re-enumerates every time the switch camera button is clicked.