### PR TITLE
Add playback rate change functionality to the replay video

### DIFF
--- a/website/coordinator.php
+++ b/website/coordinator.php
@@ -165,7 +165,6 @@ require_permission(SET_UP_PERMISSION);  // TODO: What's the correct permission?
         <option>3</option>
     </select>
 
-<?php /*
     <label for="replay_rate">Replay playback speed:</label>
     <!-- Could be any decimal value -->
     <select id="replay-rate" name="replay-rate">
@@ -175,7 +174,6 @@ require_permission(SET_UP_PERMISSION);  // TODO: What's the correct permission?
         <option selected="selected" value="0.75">0.75x</option>
         <option value="1.00">1x</option>
     </select>
-*/ ?>
     <input type="submit" data-enhanced="true" value="Submit"/>
     <input type="button" data-enhanced="true" value="Cancel"
       onclick='close_modal("#replay_settings_modal");'/>

--- a/website/replay.php
+++ b/website/replay.php
@@ -62,11 +62,13 @@ var g_remote_poller;
 var g_recorder;
 
 var g_replay_count;
+var g_replay_rate;
 
 function handle_replay_message(cmdline) {
   if (cmdline.startsWith("HELLO")) {
   } else if (cmdline.startsWith("TEST")) {
     g_replay_count = parseInt(cmdline.split(" ")[2]);
+    g_replay_rate = parseFloat(cmdline.split(" ")[3]);
     on_replay();
   } else if (cmdline.startsWith("START")) {
     g_video_name_root = cmdline.substr(6).trim();
@@ -75,6 +77,7 @@ function handle_replay_message(cmdline) {
     //  skipback and rate are ignored, but showings we can honor
     // (Must be exactly one space between fields:)
     g_replay_count = parseInt(cmdline.split(" ")[2]);
+    g_replay_rate = parseFloat(cmdline.split(" ")[3]);
     on_replay();
   } else if (cmdline.startsWith("CANCEL")) {
   } else {
@@ -162,6 +165,8 @@ $(function() {
             $("#playback-background").hide('slide');
             announce_to_interior('replay-ended');
           } else {
+            console.log('Replay rate of ' + g_replay_rate);
+            document.querySelector("#playback").playbackRate = g_replay_rate;
             document.querySelector("#playback").play();
           }
         });
@@ -197,6 +202,8 @@ function on_replay() {
 
         document.querySelector("#playback").src = URL.createObjectURL(blob);
         $("#playback-background").show('slide');
+        console.log('Replay rate of ' + g_replay_rate);
+        document.querySelector("#playback").playbackRate = g_replay_rate;
         document.querySelector("#playback").play();
       } else {
         console.log("No blob!");


### PR DESCRIPTION
As mentioned in jeffpiazza/derbynet#118 as non-functional. Thanks for the pointers in that issue, I was able to find the correct location to start playing with the functionality.

This will add playback rate changing to the replay video (test and replay). Tested working in Chrome 80 and Firefox 72.