### PR TITLE
Update kiosk.sh

### DIFF
--- a/extras/scripts/kiosk.sh
+++ b/extras/scripts/kiosk.sh
@@ -85,6 +85,9 @@ EOF
     curl --insecure --connect-timeout 6 --location --silent \
          "$DERBYNET_SERVER/index.php" > /dev/null && \
         CONTACT_OK=1
+
+# Prevent Xmessage flood when $DERBYNET_SERVER can not be reached. Especially helpful during initial setup.
+sleep 10s
 done
 
 # While loop allows recovery from browser crashes


### PR DESCRIPTION
Add time delay to initial contact of derbynet server. This prevents XMESSAGE message flood in the event the host is not yet reachable. The change is beneficial during initial setup when the host may not be available.