### PR TITLE
Bug fix: Fix handling of LaneResult with place

### DIFF
--- a/timer/derbynet-timer/src/js/timer_proxy.js
+++ b/timer/derbynet-timer/src/js/timer_proxy.js
@@ -201,7 +201,7 @@ class TimerProxy {
       if (this.result != null) {
         var was_filled = this.result.isFilled();
         var place = 0;
-        if (args.length > 2 && args[2] != null && !args[2].isEmpty()) {
+        if (args.length > 2 && args[2]) {
           // ASCII 33 is '!', signifying place
           place = args[2].charCodeAt(0) - 33 + 1;
         }


### PR DESCRIPTION
Check if the third item in args is not falsey (null, undefined, or empty). Fix TypeError calling isEmpty on string.
    
There is no isEmpty() function on Javascript strings. This causes the TimerProxy to throw a TypeError when it receives a place with the lane result. (e.g. tested on the Derby Magic timer)