### PR TITLE
Bug fix: Enable remote start

### DIFF
--- a/timer/derbynet-timer/src/js/timer_proxy.js
+++ b/timer/derbynet-timer/src/js/timer_proxy.js
@@ -173,8 +173,8 @@ class TimerProxy {
       break;
     case 'START_RACE':
       {
-        var remote_start = this.remote_start_profile;
-        if (remote_start?.has_remote_start) {
+        var remote_start = this.remote_start_profile();
+        if (this.has_remote_start()) {
           this.port_wrapper.write(remote_start.command);
         }
       }


### PR DESCRIPTION
Add missing parentheses to `remote_start_profile` function call to fix
bug where the check for a remote start was always falsey (undefined).