### PR TITLE
Addition of docker-compose support to installers

### DIFF
--- a/installer/docker-compose/.gitignore
+++ b/installer/docker-compose/.gitignore
@@ -1,0 +1,2 @@
+website/
+data/

--- a/installer/docker-compose/README.md
+++ b/installer/docker-compose/README.md
@@ -1,53 +1,53 @@
+# Docker Compose Deployment
+
 This deployment method is intended to make the server portion perhaps a bit little easier.  It uses some of the work done by Jeff and Mitchell as well, it then expands on that work to hopefully make things a bit easier for those who have docker compose installed.
 
 This docker-compose.yml file will spin up 2 docker containers and create a private docker network which is used by DerbyNet, the first container is nginx only and the other is a PHP 8.1 container running php-fpm.  Both containers are based on Alpine linux so everything is as tiny as possible and things spin up very fast.
 
-...
-$docker image ls
-REPOSITORY                         TAG       IMAGE ID       CREATED          SIZE
-docker-compose-php-fpm             latest    a2c6297a3b06   29 seconds ago   44.2MB
-docker-compose-nginx               latest    6cd6f4214c94   35 seconds ago   39.1MB
-...
+    $docker image ls
+    REPOSITORY                         TAG       IMAGE ID       CREATED          SIZE
+    docker-compose-php-fpm             latest    a2c6297a3b06   29 seconds ago   44.2MB
+    docker-compose-nginx               latest    6cd6f4214c94   35 seconds ago   39.1MB
+
 
 The docker-compose.yml file will create 2 directories in the current working directory, the first directory is 'website' which will grab a clone of the derbynet git repo website directory and the second directory which gets created is 'data' which gets mounted into the php-fpm container as a writeable area as /data.
 
-TODO: Add comments.
+## TODO: Add comments.
 
-USAGE:
-...
-git clone DERBYNET-REPO-URL
-cd debynet/installers/docker-compose
-docker compose up -d
-...
+## USAGE:
+
+    git clone DERBYNET-REPO-URL
+    cd debynet/installers/docker-compose
+    docker compose up -d
+
 
 To see the logs from both containers, you can simply run 'docker compose logs' and you'll see something like this:
-...
-DerbyNet-nginx    | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
-DerbyNet-nginx    | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
-DerbyNet-nginx    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/prep_filesystem.sh
-DerbyNet-nginx    | /usr/share/nginx/html is Empty, creating DerbyNet Website filesystem.
-DerbyNet-nginx    | Cloning into 'derbynet'...
-DerbyNet-nginx    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
-DerbyNet-nginx    | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
-DerbyNet-nginx    | 10-listen-on-ipv6-by-default.sh: info: /etc/nginx/conf.d/default.conf differs from the packaged version
-DerbyNet-nginx    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
-DerbyNet-nginx    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
-DerbyNet-nginx    | /docker-entrypoint.sh: Configuration complete; ready for start up
-DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: using the "epoll" event method
-DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: nginx/1.22.1
-DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: built by gcc 11.2.1 20220219 (Alpine 11.2.1_git20220219) 
-DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: OS: Linux 5.14.0-70.30.1.el9_0.x86_64
-DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1073741816:1073741816
-DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker processes
-DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker process 45
-DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker process 46
-DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker process 47
-DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker process 48
-DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET / HTTP/1.1" 302 5 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"
-DerbyNet-Backend  | 192.168.240.3 -  29/Nov/2022:14:18:53 +0000 "GET /index.php" 302
-DerbyNet-Backend  | 192.168.240.3 -  29/Nov/2022:14:18:53 +0000 "GET /setup.php" 200
-DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET /setup.php HTTP/1.1" 200 13323 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"
-DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET /css/jquery-ui.min.css HTTP/1.1" 200 32076 "http://192.168.1.200:8077/setup.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"
-DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET /css/mobile.css HTTP/1.1" 200 18295 "http://192.168.1.200:8077/setup.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"
-DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET /css/global.css HTTP/1.1" 200 5387 "http://192.168.1.200:8077/setup.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"
-...
+
+    DerbyNet-nginx    | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
+    DerbyNet-nginx    | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
+    DerbyNet-nginx    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/prep_filesystem.sh
+    DerbyNet-nginx    | /usr/share/nginx/html is Empty, creating DerbyNet Website filesystem.
+    DerbyNet-nginx    | Cloning into 'derbynet'...
+    DerbyNet-nginx    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
+    DerbyNet-nginx    | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
+    DerbyNet-nginx    | 10-listen-on-ipv6-by-default.sh: info: /etc/nginx/conf.d/default.conf differs from the packaged version
+    DerbyNet-nginx    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
+    DerbyNet-nginx    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
+    DerbyNet-nginx    | /docker-entrypoint.sh: Configuration complete; ready for start up
+    DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: using the "epoll" event method
+    DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: nginx/1.22.1
+    DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: built by gcc 11.2.1 20220219 (Alpine 11.2.1_git20220219) 
+    DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: OS: Linux 5.14.0-70.30.1.el9_0.x86_64
+    DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1073741816:1073741816
+    DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker processes
+    DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker process 45
+    DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker process 46
+    DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker process 47
+    DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker process 48
+    DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET / HTTP/1.1" 302 5 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"
+    DerbyNet-Backend  | 192.168.240.3 -  29/Nov/2022:14:18:53 +0000 "GET /index.php" 302
+    DerbyNet-Backend  | 192.168.240.3 -  29/Nov/2022:14:18:53 +0000 "GET /setup.php" 200
+    DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET /setup.php HTTP/1.1" 200 13323 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"
+    DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET /css/jquery-ui.min.css HTTP/1.1" 200 32076 "http://192.168.1.200:8077/setup.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"
+    DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET /css/mobile.css HTTP/1.1" 200 18295 "http://192.168.1.200:8077/setup.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"
+    DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET /css/global.css HTTP/1.1" 200 5387 "http://192.168.1.200:8077/setup.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"

--- a/installer/docker-compose/README.md
+++ b/installer/docker-compose/README.md
@@ -1,0 +1,53 @@
+This deployment method is intended to make the server portion perhaps a bit little easier.  It uses some of the work done by Jeff and Mitchell as well, it then expands on that work to hopefully make things a bit easier for those who have docker compose installed.
+
+This docker-compose.yml file will spin up 2 docker containers and create a private docker network which is used by DerbyNet, the first container is nginx only and the other is a PHP 8.1 container running php-fpm.  Both containers are based on Alpine linux so everything is as tiny as possible and things spin up very fast.
+
+...
+$docker image ls
+REPOSITORY                         TAG       IMAGE ID       CREATED          SIZE
+docker-compose-php-fpm             latest    a2c6297a3b06   29 seconds ago   44.2MB
+docker-compose-nginx               latest    6cd6f4214c94   35 seconds ago   39.1MB
+...
+
+The docker-compose.yml file will create 2 directories in the current working directory, the first directory is 'website' which will grab a clone of the derbynet git repo website directory and the second directory which gets created is 'data' which gets mounted into the php-fpm container as a writeable area as /data.
+
+TODO: Add comments.
+
+USAGE:
+...
+git clone DERBYNET-REPO-URL
+cd debynet/installers/docker-compose
+docker compose up -d
+...
+
+To see the logs from both containers, you can simply run 'docker compose logs' and you'll see something like this:
+...
+DerbyNet-nginx    | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
+DerbyNet-nginx    | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
+DerbyNet-nginx    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/prep_filesystem.sh
+DerbyNet-nginx    | /usr/share/nginx/html is Empty, creating DerbyNet Website filesystem.
+DerbyNet-nginx    | Cloning into 'derbynet'...
+DerbyNet-nginx    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
+DerbyNet-nginx    | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
+DerbyNet-nginx    | 10-listen-on-ipv6-by-default.sh: info: /etc/nginx/conf.d/default.conf differs from the packaged version
+DerbyNet-nginx    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
+DerbyNet-nginx    | /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
+DerbyNet-nginx    | /docker-entrypoint.sh: Configuration complete; ready for start up
+DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: using the "epoll" event method
+DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: nginx/1.22.1
+DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: built by gcc 11.2.1 20220219 (Alpine 11.2.1_git20220219) 
+DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: OS: Linux 5.14.0-70.30.1.el9_0.x86_64
+DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1073741816:1073741816
+DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker processes
+DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker process 45
+DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker process 46
+DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker process 47
+DerbyNet-nginx    | 2022/11/29 14:13:58 [notice] 1#1: start worker process 48
+DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET / HTTP/1.1" 302 5 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"
+DerbyNet-Backend  | 192.168.240.3 -  29/Nov/2022:14:18:53 +0000 "GET /index.php" 302
+DerbyNet-Backend  | 192.168.240.3 -  29/Nov/2022:14:18:53 +0000 "GET /setup.php" 200
+DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET /setup.php HTTP/1.1" 200 13323 "-" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"
+DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET /css/jquery-ui.min.css HTTP/1.1" 200 32076 "http://192.168.1.200:8077/setup.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"
+DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET /css/mobile.css HTTP/1.1" 200 18295 "http://192.168.1.200:8077/setup.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"
+DerbyNet-nginx    | 192.168.1.16 - - [29/Nov/2022:14:18:53 +0000] "GET /css/global.css HTTP/1.1" 200 5387 "http://192.168.1.200:8077/setup.php" "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36" "-"
+...

--- a/installer/docker-compose/README.md
+++ b/installer/docker-compose/README.md
@@ -12,7 +12,9 @@ This docker-compose.yml file will spin up 2 docker containers and create a priva
 
 The docker-compose.yml file will create 2 directories in the current working directory, the first directory is 'website' which will grab a clone of the derbynet git repo website directory and the second directory which gets created is 'data' which gets mounted into the php-fpm container as a writeable area as /data.
 
-## TODO: Add comments.
+## TODO:
+
+Test more scenarios.
 
 ## USAGE:
 

--- a/installer/docker-compose/docker-compose.yml
+++ b/installer/docker-compose/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  nginx:
+    build: 
+      context: ./nginx
+    container_name: DerbyNet-nginx  
+    ports:   
+     - 8077:80
+    networks:
+      - DerbyNet
+    depends_on:
+      - php-fpm
+    volumes:
+      - ./website:/usr/share/nginx/html
+      - ./nginx/derbynet.conf:/etc/nginx/derbynet/location.snippet
+  php-fpm:
+    build: 
+      context: ./php-fpm
+      args:
+        TZ: America/New_York
+        MAX_UPLOAD_SIZE: 16M
+    container_name: DerbyNet-Backend
+    ports:
+      - 9999:9000
+    networks:
+      - DerbyNet
+    volumes:
+      - ./website:/usr/share/nginx/html
+      - ./data:/data
+networks:
+  DerbyNet:

--- a/installer/docker-compose/docker-compose.yml
+++ b/installer/docker-compose/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: ./nginx
     container_name: DerbyNet-nginx  
     ports:   
-     - 8077:80
+     - 8077:80 #8077 is exposed, this can be changed to whatever is desired.
     networks:
       - DerbyNet
     depends_on:
@@ -16,11 +16,11 @@ services:
     build: 
       context: ./php-fpm
       args:
-        TZ: America/New_York
-        MAX_UPLOAD_SIZE: 16M
+        TZ: America/New_York #Should be set to your timezone
+        MAX_UPLOAD_SIZE: 16M #This should be a good number but if you are uploading huge photos then you may need to expand this.
     container_name: DerbyNet-Backend
     ports:
-      - 9999:9000
+      - 9999:9000 #Port does not need to be exposed, 9999 is used as a random usable port in my environment
     networks:
       - DerbyNet
     volumes:

--- a/installer/docker-compose/nginx/Dockerfile
+++ b/installer/docker-compose/nginx/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:stable-alpine
+RUN apk add bash git
+RUN echo -e "include /etc/nginx/derbynet/location.snippet;" > /etc/nginx/conf.d/default.conf
+COPY prep_filesystem.sh /docker-entrypoint.d/.
+RUN chmod 755 /docker-entrypoint.d/prep_filesystem.sh

--- a/installer/docker-compose/nginx/Dockerfile
+++ b/installer/docker-compose/nginx/Dockerfile
@@ -1,5 +1,11 @@
 FROM nginx:stable-alpine
+
+#Install all of the dependancies
 RUN apk add bash git
+
+#Insert our nginx config loader
 RUN echo -e "include /etc/nginx/derbynet/location.snippet;" > /etc/nginx/conf.d/default.conf
+
+#Copy the script into place which sets up the websites directory if it doesn't exist and then set the permissions on that file
 COPY prep_filesystem.sh /docker-entrypoint.d/.
 RUN chmod 755 /docker-entrypoint.d/prep_filesystem.sh

--- a/installer/docker-compose/nginx/derbynet.conf
+++ b/installer/docker-compose/nginx/derbynet.conf
@@ -1,0 +1,24 @@
+# upstream php {
+#     server  php-fpm:9000;
+# }
+
+server {
+    listen       80;
+    server_name  localhost;
+
+
+    root   /usr/share/nginx/html;
+    index  index.php index.html index.htm;
+    #try_files $uri $uri/ /index.php?$args;
+
+
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php-fpm:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+}

--- a/installer/docker-compose/nginx/prep_filesystem.sh
+++ b/installer/docker-compose/nginx/prep_filesystem.sh
@@ -7,11 +7,16 @@ then
     else
         echo "$WWW_ROOT is Empty, creating DerbyNet Website filesystem."
         cd /
-        git clone https://github.com/jeffpiazza/derbynet.git && \
-            mv /derbynet/website/* /usr/share/nginx/html/. && \
-            mv /derbynet/templates/banner.inc /usr/share/nginx/html/inc/banner.inc && \
-            rm -rf /derbynet && \
-            test -d $WWW_ROOT/local || mkdir -m 777 $WWW_ROOT/local
+        echo "Cloning Jeff's repo."
+        git clone https://github.com/jeffpiazza/derbynet.git
+        echo "Moving the website files into $WWW_ROOT."
+        mv /derbynet/website/* $WWW_ROOT/.
+        echo "Moving the missing banner.inc file into place."
+        mv /derbynet/templates/banner.inc $WWW_ROOT/inc/banner.inc
+        echo "Getting rid of the Derbynet repo to conserve space."
+        rm -rf /derbynet
+        echo "Fixing permissions on $WWW_ROOT/local"
+        test -d $WWW_ROOT/local || mkdir -m 777 $WWW_ROOT/local
     fi
 else
 	echo "Directory $DIR not found."

--- a/installer/docker-compose/nginx/prep_filesystem.sh
+++ b/installer/docker-compose/nginx/prep_filesystem.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+WWW_ROOT=/usr/share/nginx/html
+if [ -d "$WWW_ROOT" ]
+then
+    if [ "$(ls -A $WWW_ROOT)" ]; then
+        echo "$WWW_ROOT is not Empty, using existing structure."
+    else
+        echo "$WWW_ROOT is Empty, creating DerbyNet Website filesystem."
+        cd /
+        git clone https://github.com/jeffpiazza/derbynet.git && \
+            mv /derbynet/website/* /usr/share/nginx/html/. && \
+            mv /derbynet/templates/banner.inc /usr/share/nginx/html/inc/banner.inc && \
+            rm -rf /derbynet && \
+            test -d $WWW_ROOT/local || mkdir -m 777 $WWW_ROOT/local
+    fi
+else
+	echo "Directory $DIR not found."
+fi

--- a/installer/docker-compose/php-fpm/Dockerfile
+++ b/installer/docker-compose/php-fpm/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:3.17
+ARG TZ
+ARG MAX_UPLOAD_SIZE
+RUN apk add libcurl bash php81-fpm php81-curl php81-gd php81-sqlite3 php81-odbc php81-session php81-pdo php81-pdo_sqlite
+RUN echo -e "access.log = /proc/self/fd/2" >> /etc/php81/php-fpm.conf
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+RUN sed -i "s/upload_max_filesize = 2M/upload_max_filesize = ${MAX_UPLOAD_SIZE}/g" /etc/php81/php.ini
+RUN sed -i "s/post_max_size = 8M/post_max_size = ${MAX_UPLOAD_SIZE}/g" /etc/php81/php.ini
+RUN sed -i "s/memory_limit = 128M/memory_limit = 256M/g" /etc/php81/php.ini
+RUN sed -i "s/session.gc_maxlifetime = 1440/session.gc_maxlifetime = 28800/g" /etc/php81/php.ini
+RUN sed -i "s/listen = 127.0.0.1:9000/listen = 0.0.0.0:9000/g" /etc/php81/php-fpm.d/www.conf
+RUN sed -i "s/;chdir = \/var\/www/chdir = \/usr\/share\/nginx\/html/g" /etc/php81/php-fpm.d/www.conf
+RUN test -d /data || mkdir -m 777 /data
+RUN chown -R nobody:nobody /data
+RUN chmod -R 777 /data
+CMD chown -R nobody:nobody /data; /usr/sbin/php-fpm81 -F
+EXPOSE 9000

--- a/installer/docker-compose/php-fpm/Dockerfile
+++ b/installer/docker-compose/php-fpm/Dockerfile
@@ -1,17 +1,35 @@
 FROM alpine:3.17
+
+#Setup some variables we'll be using
 ARG TZ
 ARG MAX_UPLOAD_SIZE
+
+#Install all of the dependancies
 RUN apk add libcurl bash php81-fpm php81-curl php81-gd php81-sqlite3 php81-odbc php81-session php81-pdo php81-pdo_sqlite
+
+#Send the logs to someplace docker can use them
 RUN echo -e "access.log = /proc/self/fd/2" >> /etc/php81/php-fpm.conf
+
+#Set the timezone because PHP has liked it that way since PHP5
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+#Set some PHP.ini Vars
 RUN sed -i "s/upload_max_filesize = 2M/upload_max_filesize = ${MAX_UPLOAD_SIZE}/g" /etc/php81/php.ini
 RUN sed -i "s/post_max_size = 8M/post_max_size = ${MAX_UPLOAD_SIZE}/g" /etc/php81/php.ini
 RUN sed -i "s/memory_limit = 128M/memory_limit = 256M/g" /etc/php81/php.ini
 RUN sed -i "s/session.gc_maxlifetime = 1440/session.gc_maxlifetime = 28800/g" /etc/php81/php.ini
+
+#Fix some php-fpm settings so they work with this application
 RUN sed -i "s/listen = 127.0.0.1:9000/listen = 0.0.0.0:9000/g" /etc/php81/php-fpm.d/www.conf
 RUN sed -i "s/;chdir = \/var\/www/chdir = \/usr\/share\/nginx\/html/g" /etc/php81/php-fpm.d/www.conf
+
+#Set some permissions on some directories
 RUN test -d /data || mkdir -m 777 /data
 RUN chown -R nobody:nobody /data
 RUN chmod -R 777 /data
+
+#Fix the permisions on /data and start the php-fpm process 
 CMD chown -R nobody:nobody /data; /usr/sbin/php-fpm81 -F
+
+#Expose port 9000
 EXPOSE 9000


### PR DESCRIPTION
I can't say this is an improvement over any existing processes but it does give users the option of using docker compose as a deployment method.  Basic testing has been done, the application loads in a browser, you can create the required sqlite database file and you can create writeable directories for photos and videos.  

Anyway, I had some time over the Thanksgiving Holiday so I rolled this up into a commit, I do still need to add comments to my docker-compose.yml and my Dockerfiles, I'll try to get those in later this week.

Tested on the following:
```
$docker version
Client: Docker Engine - Community
 Version:           20.10.21
 API version:       1.41
 Go version:        go1.18.7
 Git commit:        baeda1f
 Built:             Tue Oct 25 18:02:16 2022
 OS/Arch:           linux/amd64
 Context:           default
 Experimental:      true

Server: Docker Engine - Community
 Engine:
  Version:          20.10.21
  API version:      1.41 (minimum version 1.12)
  Go version:       go1.18.7
  Git commit:       3056208
  Built:            Tue Oct 25 18:00:01 2022
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.6.9
  GitCommit:        1c90a442489720eec95342e1789ee8a5e1b9536f
 runc:
  Version:          1.1.4
  GitCommit:        v1.1.4-0-g5fd4c4d
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
$docker compose version
Docker Compose version v2.12.2
```

