### PR TITLE
Update ondeck.js

### DIFF
--- a/website/js/ondeck.js
+++ b/website/js/ondeck.js
@@ -56,6 +56,8 @@ function repopulate_schedule(json) {
       }
       var row = $("<tr/>").appendTo("table#schedule");
       ++rowno;
+	  //new heat reset lane count to zero to ensure correct byes are populated
+	  lane = 0;
       row_has_photos = false;
       prev_racerids = racerids;
       racerids = Array(nlanes).fill(null);
@@ -69,8 +71,8 @@ function repopulate_schedule(json) {
         .appendTo(row);
       roundid = cell['roundid'];
       heat = cell['heat'];
-    }
-    add_byes(cell['lane'] - 1 - lane);
+    } 
+    add_byes(row, cell['lane'] - 1 - lane);
 
     var td = $("<td/>").appendTo(row).css({'width': td_width_vh + 'vh'});
     td.addClass('lane_' + cell['lane'])


### PR DESCRIPTION
Correct issue with one deck not populating bye  for a heat.  When the row (aka heat number is increased reset the lane index to zero the the correct number of bye lanes are inserted befor lanes with the first racers. added the row object the     add_byes call that was missing. this added bye lanes between lane with racers.  