### PR TITLE
Fixing typo: qualifiing -> qualifying

### DIFF
--- a/website/inc/standings.inc
+++ b/website/inc/standings.inc
@@ -730,7 +730,7 @@ class StandingsOracle {
         }
 
         if (count($cl['constituents']) > 0) {
-          $catalog[] = array('name' => $cl['class'].' Qualifiing Rounds',
+          $catalog[] = array('name' => $cl['class'].' Qualifying Rounds',
                              'key' => stkey_qual($classid),
                              'presentation' => 'qual');
         }


### PR DESCRIPTION
Hello! I noticed a typo in the application while I was prepping for our derby this weekend and figured I would open a PR for it. See screenshot below. Thanks for everything you do for DerbyNet and for making it so easy to run a derby for our kids!

<img width="465" alt="image" src="https://user-images.githubusercontent.com/245897/216792774-380af946-37d0-4677-be36-a7af71004bca.png">
