### PR TITLE
Fix proxy urls

### DIFF
--- a/website/inc/locked.inc
+++ b/website/inc/locked.inc
@@ -35,6 +35,11 @@ function preferred_urls($use_https = false) {
     $addrs = gethostbynamel(gethostname());
     $urls = array();
 
+    // accomodate hosted on proxy servers (eg. nginx)
+    if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+      $addrs = array($_SERVER['HTTP_HOST']);
+    }
+
     // IIS apparently doesn't set REQUEST_URI.
     if (isset($_SERVER['REQUEST_URI'])) {
       $uri = dirname($_SERVER['REQUEST_URI']);


### PR DESCRIPTION
This fixes URLs when `derbynet-server` is hosted on one server and served by a different (proxy) server (NGINX).