### PR TITLE
Make DNF handling clearer

### DIFF
--- a/website/inc/standings.inc
+++ b/website/inc/standings.inc
@@ -587,7 +587,7 @@ class StandingsOracle {
       } else {
         echo "<td>".sprintf($time_format, $row['avg'])."</td>";
         echo "<td>".sprintf($time_format, $row['best'])."</td>";
-        echo "<td>".sprintf($time_format, $row['worst'])."</td>";
+        echo "<td>".sprintf($time_format, $row['worst']).(floatval($row['worst']) > 9.9 ? "(DNF)" : "")."</td>";
       }
       echo "</tr>\n";
     }

--- a/website/js/coordinator-controls.js
+++ b/website/js/coordinator-controls.js
@@ -122,7 +122,7 @@ function on_manual_results_button_click(should_trigger_replay) {
         racer_table.append("<tr><td>" + racer.lane + "</td>"
                            + "<td>" + racer.name + "</td>"
                            + "<td>" + racer.carnumber + "</td>"
-                           + "<td><input class='lane-time' type='number' step='0.00001'"
+                           + "<td><input class='lane-time' type='number' step='0.000001'"
                                + " name='lane" + racer.lane + "'" 
                                + " value='" + racer.finishtime + "'/>"
                            + "</td>"
@@ -130,6 +130,22 @@ function on_manual_results_button_click(should_trigger_replay) {
         if (racer.finishtime) {
             any_results = true;
         }
+    }
+
+    // Add a note to tell the user how to log a DNF
+    if ($("#note-for-table").length === 0) {
+        $(racer_table).after(
+          $("<div>")
+            .addClass("note")
+            .css({
+              "text-align": "right",
+              "padding": "5px 10px",
+              "background-color": "#f0f0f0",
+              "border-radius": "4px"
+            })
+            .attr('id', 'note-for-table')
+            .text("Note: Enter 9.999 for a DNF.")
+      );
     }
 
     if (any_results) {

--- a/website/js/coordinator-controls.js
+++ b/website/js/coordinator-controls.js
@@ -122,7 +122,7 @@ function on_manual_results_button_click(should_trigger_replay) {
         racer_table.append("<tr><td>" + racer.lane + "</td>"
                            + "<td>" + racer.name + "</td>"
                            + "<td>" + racer.carnumber + "</td>"
-                           + "<td><input class='lane-time' type='number' step='0.000001'"
+                           + "<td><input class='lane-time' type='number' step='0.00001'"
                                + " name='lane" + racer.lane + "'" 
                                + " value='" + racer.finishtime + "'/>"
                            + "</td>"

--- a/website/js/coordinator-poll.js
+++ b/website/js/coordinator-poll.js
@@ -472,10 +472,10 @@ function generate_current_heat_racers(new_racers, current, nlanes) {
 
     var result = "";
     if (r) {
-      result = current.use_points ? r.finishplace : r.finishtime;
+      result = current.use_points ? r.finishplace : r.finishtime > 9.9 ? "DNF" : r.finishtime;
     }
     if (holding && hr) {
-      result = current.use_points ? hr.place : hr.time;
+      result = current.use_points ? hr.place : hr.time > 9.9 ? "DNF" : hr.time;
     }
     racers_table.append('<tr><td>' + lane + '</td>'
                         + '<td>' + (r ? r.carnumber : '') + '</td>'

--- a/website/js/now-racing-columnar.js
+++ b/website/js/now-racing-columnar.js
@@ -61,7 +61,8 @@ class ResultAnimator {
       let lane = heat_results[i].lane;
       let racer_entry_div = $("div.lane").eq(lane_to_column(lane)).find("div.racer-entry:first");
       let time_div = racer_entry_div.find("div.heat_time");
-      time_div.text(Number.parseFloat(heat_results[i].time).toFixed(precision))
+      var isDnf = heat_results[i].time > 9.9;
+      time_div.text(isDnf ? "DNF" : Number.parseFloat(heat_results[i].time).toFixed(precision))
         .css({'background-color': 'red'});
       let time_animation = new Promise(function(result) {
         time_div.animate({'backgroundColor': '#c0c0c0'},

--- a/website/js/now-racing.js
+++ b/website/js/now-racing.js
@@ -313,9 +313,10 @@ function process_polling_result(data) {
       var place = hr.place;
       place_to_lane[parseInt(place)] = lane;
 
+      var isDnf = hr.time > 9.9;
       $('[data-lane="' + lane + '"] .time')
         .css({opacity: 100})
-        .text(Number.parseFloat(hr.time).toFixed(precision));
+        .text(isDnf ? "DNF" : Number.parseFloat(hr.time).toFixed(precision));
       if (FlyerAnimation.ok_to_animate) {
         $('[data-lane="' + lane + '"] .place').css({opacity: 0});
       }
@@ -323,7 +324,7 @@ function process_polling_result(data) {
       if (hr.speed != '') {
         $('[data-lane="' + lane + '"] .speed')
           .css({opacity: 100})
-          .text(hr.speed);
+          .text(isDnf ? "--" : hr.speed);
       }
     }
 

--- a/website/js/ondeck.js
+++ b/website/js/ondeck.js
@@ -129,9 +129,13 @@ function repopulate_schedule(json) {
       td.addClass('in_prev');
     }
     racerids[cell['lane']] = cell['racerid'];
+    var time = cell['result'].substring(1);
+    if (time > 9.9) {
+      time = "DNF";
+    }
     td.append($('<div/>').addClass('car').text(cell['carnumber']))
       .append($('<div/>').addClass('racer').text(cell['name']))
-      .append($('<div/>').addClass('time').text(cell['result'].substring(1))
+      .append($('<div/>').addClass('time').text(time)
               .css('display', cell['result'] ? 'block' : 'none'));
 
     var photo_div = $("<div/>").addClass('ondeck_photo').appendTo(td);

--- a/website/js/results-by-racer-update.js
+++ b/website/js/results-by-racer-update.js
@@ -86,8 +86,11 @@ function rewrite_table_sections(rounds, keys, index, completed) {
 function update_results(results) {
   for (var i = 0; i < results.length; ++i) {
     var result = results[i];
-    $("td.resultid_" + result.resultid + " span.time").text(
-      result.outcome[0] == 'x' ? result.outcome.substring(1) : result.outcome);
+    var time = result.outcome[0] == 'x' ? result.outcome.substring(1) : result.outcome;
+    if (time > 9.9) {
+      time = "DNF";
+    }
+    $("td.resultid_" + result.resultid + " span.time").text(time);
   }
 
   if (g_as_kiosk) {


### PR DESCRIPTION
The DNF handling was really unclear to me and made handling it a bit of a pain. It also made it somewhat difficult to understand until I emailed Jeff a bit. 
To fix it, I made DNF times (>9.9) be displayed as 'DNF' to make it clearer for audiences.
Also added a note to the 'Manual Results' page to indicate that 9.999 will result in a DNF time.
## Manual Results
![image](https://github.com/user-attachments/assets/cff071a2-3ed2-4d32-83f6-35c337c86104)

## Race Dashboard
![image](https://github.com/user-attachments/assets/9a2f3c7e-02ce-4bc4-b6d1-29e3ee95c298)

## Race Standings
Note: This left the original time so the averages work out when people try to guess what they should have since the 9.999 gets averaged in.
![image](https://github.com/user-attachments/assets/d30e7c37-eb44-4f9e-8e4a-7649c54860f1)

## Results by Racer
![image](https://github.com/user-attachments/assets/685ceedc-e0ba-4129-9f02-0ded9d15c623)

## Racers on Deck
![image](https://github.com/user-attachments/assets/38009f88-cecf-431a-9f77-4041a5696a3c)

## Now Racing Kiosk
![image](https://github.com/user-attachments/assets/afacb9c4-360a-41bf-ac7a-6658e58a9828)

## Now Racing Columnar Kiosk
![image](https://github.com/user-attachments/assets/9ea9060f-98c0-4961-be4f-9f0b1fc4e28d)
