### PR TITLE
Implement lag delay and extend replay length durations to 12 seconds.

### DIFF
--- a/website/coordinator.php
+++ b/website/coordinator.php
@@ -225,6 +225,9 @@ input.lane-time::-webkit-outer-spin-button {
         <!-- <option value="5500">5.5</option> -->
         <option value="6000">6.0</option>
         <!-- <option value="6500">6.5</option> -->
+        <option value="8000">8.0</option>
+        <option value="10000">10.0</option>
+        <option value="12000">12.0</option>
     </select>
 
     <label for="replay-num-showings">Number of times to show replay:</label>


### PR DESCRIPTION
This adds a parameter to delay the replay recording by the given duration in seconds.  This differs from the delay parameter provided in the replace kiosk in that it actually delays the recording start instead of simply delaying the replay.

This was implemented as we found the "live recording" from the replay kiosk was often a few seconds behind, and in some extreme cases would completely miss the replay by ending before the race actually started in the replay stream.

Fine tuning this parameter helped us to reliably capture the race.

This PR also extends the replay duration options as we found a longer duration would help in ensuring we captured the race.