### PR TITLE
Add .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ dist/
 adapter-webrtc/
 .idea
 *.iml
+.DS_Store


### PR DESCRIPTION
Adds .DS_Store to .gitignore to prevent macOS Finder metadata files from being committed to the repository. These files are automatically created by macOS when browsing directories in Finder and have no value in version control.