### PR TITLE
Redirect Docker logs to stdout/stderr and add ant build target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -19,6 +19,8 @@
   <!-- Contains a recent copy of
         https://webrtc.github.io/adapter/adapter-latest.js -->
   <property name="webrtc-adapter-cache" location="adapter-webrtc"/>
+    <property name="docker.image" value="derbynet_server"/>
+    <property name="docker.platform" value="linux/amd64,linux/arm64"/>
 
   <condition property="is_mac">
     <os family="mac"/>
@@ -570,7 +572,48 @@
 </target>
 
 <target name="docker-deps" depends="generated, timer-in-browser"
-        description="Builds prerequisites for building derbynet_server docker image">
+    description="Builds prerequisites for building derbynet_server docker image">
+</target>
+
+<target name="check-buildx">
+  <exec executable="docker" resultproperty="buildx.exit.code" failonerror="false" outputproperty="buildx.out" errorproperty="buildx.err">
+    <arg value="buildx"/>
+    <arg value="version"/>
+  </exec>
+  <condition property="buildx.available">
+    <equals arg1="${buildx.exit.code}" arg2="0"/>
+  </condition>
+</target>
+
+<target name="docker-build-x" if="buildx.available">
+  <echo message="Using docker buildx..."/>
+  <exec executable="docker" failonerror="true">
+    <arg value="buildx"/>
+    <arg value="build"/>
+    <arg value="--platform"/>
+    <arg value="${docker.platform}"/>
+    <arg value="-t"/>
+    <arg value="${docker.image}"/>
+    <arg value="-f"/>
+    <arg value="installer/docker/Dockerfile"/>
+    <arg value="."/>
+  </exec>
+</target>
+
+<target name="docker-build-default" unless="buildx.available">
+  <echo message="Using standard docker build..."/>
+  <exec executable="docker" failonerror="true">
+    <arg value="build"/>
+    <arg value="-t"/>
+    <arg value="${docker.image}"/>
+    <arg value="-f"/>
+    <arg value="installer/docker/Dockerfile"/>
+    <arg value="."/>
+  </exec>
+</target>
+
+<target name="docker-build" depends="docker-deps, check-buildx, docker-build-x, docker-build-default"
+    description="Build derbynet_server Docker image. Use -Ddocker.image=... to override">
 </target>
 
 <target name="demo" description="demo">

--- a/installer/docker/Dockerfile
+++ b/installer/docker/Dockerfile
@@ -47,7 +47,7 @@ RUN rm -rf $WWW_ROOT/local/* $WWW_ROOT/index*.html && \
 
 # The set-timeout.sh script may be needed to prevent timeouts under automated testing.
 # Under "normal" production use, stock timeouts are probably OK.
-COPY installer/docker/alpine-* installer/docker/set-timeout.sh /usr/local/bin
+COPY installer/docker/alpine-* installer/docker/set-timeout.sh /usr/local/bin/
 
 # How large are the pictures you want to upload?  8M covers an 18-megapixel
 # photo.
@@ -55,6 +55,12 @@ ENV MAX_UPLOAD_SIZE=16M
 
 RUN bash /usr/local/bin/alpine-snakeoil.sh && \
     bash /usr/local/bin/alpine-configure-nginx.sh
+
+# Redirect logs to stdout/stderr
+RUN ln -sf /dev/stdout /var/log/nginx/access.log && \
+    ln -sf /dev/stderr /var/log/nginx/error.log && \
+    sed -i 's/^;* *error_log = .*/error_log = \/dev\/stderr/' /etc/php84/php-fpm.conf && \
+    sed -i 's/^;* *catch_workers_output = .*/catch_workers_output = yes/' /etc/php84/php-fpm.d/www.conf
 
 VOLUME /var/lib/derbynet
 


### PR DESCRIPTION
This PR updates the Docker configuration to adhere to container logging best practices and simplifies the build process.

- Logging: Configures Nginx and PHP-FPM to write logs to /dev/stdout and /dev/stderr.
    - This enables docker logs to capture application output, which was previously hidden in internal log files.
    - It resolves potential permission issues when running containers with read-only filesystems or specific volume mounts (e.g., NFS) where writing to /var/log might fail.
- Build: Adds a docker-build target to [build.xml](code-assist-path:/home/john/repos/derbynet/build.xml) to streamline creating the container image.