### PR TITLE
Refactor checkin screen to use partials

### DIFF
--- a/website/checkin.php
+++ b/website/checkin.php
@@ -11,6 +11,8 @@ require_once('inc/classes.inc');
 require_once('inc/partitions.inc');
 require_once('inc/locked.inc');
 require_once('inc/checkin-table.inc');
+require_once('inc/checkin-table-data.inc');
+require_once('partials/partials_helper.inc');
 
 require_permission(CHECK_IN_RACERS_PERMISSION);
 
@@ -42,16 +44,12 @@ if (isset($_GET['order']) && in_array($_GET['order'], ['name', 'class', 'car', '
 if (!$order)
     $order = 'name';
 
-// The table of racers can be presented in order by name, car, or class (and
-// then by name within the class).  Each sortable column has a header which is a
-// link to change the ordering, with the exception that the header for the
-// column for ordering currently in use is NOT a link (because it wouldn't do
-// anything).
-function column_header($text, $o) {
-  global $order;
-  return "<a data-order='".$o."' "
-      .($o == $order ? "" : " href='#'").">".$text."</a>";
+
+function to_json($array) {
+    return json_encode($array, JSON_NUMERIC_CHECK | JSON_UNESCAPED_SLASHES |
+            JSON_HEX_AMP | JSON_HEX_TAG | JSON_HEX_APOS);
 }
+
 ?><!DOCTYPE html>
 <html>
 <head>
@@ -75,12 +73,6 @@ var g_action_on_barcode = "<?php
 var g_preferred_urls = <?php echo json_encode(preferred_urls(/*use_https=*/true),
                                               JSON_HEX_TAG | JSON_HEX_AMP | JSON_PRETTY_PRINT); ?>;
 
-function set_checkin_table_height() {
-  $("#main-checkin-table-div").height(
-      $(window).height() - $(".banner").height() - $("#top-buttons").height());
-}
-$(function() { set_checkin_table_height(); });
-$(window).on('resize', set_checkin_table_height);
 </script>
 <script type="text/javascript" src="js/mobile.js"></script>
 <script type="text/javascript" src="js/dashboard-ajax.js"></script>
@@ -96,335 +88,49 @@ $(window).on('resize', set_checkin_table_height);
 <body>
 <?php
 make_banner('Racer Check-In');
+
+echo include_partial('partials/checkin/top_buttons.php', array(
+        'include_new_racer_button' => have_permission(REGISTER_NEW_RACER_PERMISSION),
+));
+
+// Main check-in table
+
+list($classes, $classseq, $ranks, $rankseq) = classes_and_ranks();
+$racers = get_racers($order);
+
+echo include_partial('partials/checkin/main_checkin_table.php', array(
+        'use_xbs' => $xbs,
+        'xbs_award_name' => $xbs_award_name,
+        'partition_label' => partition_label(),
+        'racers' => $racers,
+        'ranks' => $ranks
+));
+
 ?>
-
-<div id="top-buttons" class="block_buttons">
-  <img id="barcode-button" src="img/barcode.png"
-      onclick="handle_barcode_button_click()"/>
-  <input id="mobile-button" type="button" value="Mobile"
-      onclick="handle_qrcode_button_click()"/>
-
-  <input class="bulk_button"
-        type="button" value="Bulk"
-        onclick='show_bulk_form();'/>
-<?php if (have_permission(REGISTER_NEW_RACER_PERMISSION)) { ?>
-      <input type="button" value="New Racer"
-        onclick='show_new_racer_form();'/>
-<?php } else { ?>
-          <div style='padding: 10px 15px; font-size: x-large; line-height: 1.3; margin-bottom: 20px; margin-top: 3px; '>&nbsp;</div>
-<?php } ?>
-</div>
-
-<div id="main-checkin-table-div">
-<table id="main-checkin-table" class="main_table">
-<thead>
-  <tr>
-    <th/>
-    <th><?php
-      echo column_header(htmlspecialchars(partition_label(), ENT_QUOTES, 'UTF-8'), 'partition');
-    ?></th>
-    <th><?php echo column_header('Car Number', 'car'); ?></th>
-    <th>Photo</th>
-    <th><?php echo column_header('Last Name', 'name'); ?></th>
-    <th>First Name</th>
-    <th>Car Name &amp; From</th>
-    <th>Passed?</th>
-    <?php if ($xbs) {
-        echo '<th>'.$xbs_award_name.'</th>';
-    } ?>
-  </tr>
-</thead>
-
-<tbody id="main_tbody">
-
-</tbody>
-</table>
-</div>
 
 <?php
+// Modals
+echo include_partial('partials/checkin/edit_racer_modal.php', array(
+        'partitions' => get_partitions(),
+        'partition_label' => partition_label(),
+        'partition_label_pl' => partition_label_pl(),
+));
+echo include_partial('partials/checkin/photo_modal.php', array(
+        'showSettingsWarning' => headshots()->status() != 'ok',
+));
+echo include_partial('partials/checkin/bulk_modal.php');
 
-  $stmt = $db->query('SELECT partitionid, name,'
-                     .'  (SELECT COUNT(*) FROM RegistrationInfo'
-                     .'     WHERE RegistrationInfo.partitionid = Partitions.partitionid) AS count'
-                     .' FROM Partitions'
-                     .' ORDER BY sortorder');
-  $partitions = $stmt->fetchAll(PDO::FETCH_ASSOC);
-  if (count($partitions) == 0) {
-    // 0 won't be used as a partitionid, but will cause the server to create a new
-    // partition with default name.
-    $partitions[] = array('partitionid' => 0,
-                          'name' => DEFAULT_PARTITION_NAME);
-  }
+list($car_numbering_mult, $car_numbering_smallest) = read_car_numbering_values();
+echo include_partial('partials/checkin/bulk_renumbering_modal.php', array(
+        'car_numbering_mult' => $car_numbering_mult,
+        'car_numbering_smallest' => $car_numbering_smallest,
+        'partition_label_lc' => partition_label_lc()
+));
 
+echo include_partial('partials/checkin/barcode_settings_modal.php');
+echo include_partial('partials/checkin/qrcode_settings_modal.php');
 
-  list($classes, $classseq, $ranks, $rankseq) = classes_and_ranks();
-
-$sql = checkin_table_SELECT_FROM_sql()
-    .' ORDER BY '
-          .($order == 'car' ? 'carnumber, lastname, firstname' :
-            ($order == 'class'  ? 'class_sort, rank_sort, lastname, firstname' :
-             ($order == 'partition' ? 'partition_sortorder, lastname, firstname' :
-              'lastname, firstname')));
-
-$stmt = $db->prepare($sql);
-$stmt->execute(array(':xbs_award_name' => xbs_award()));
 ?>
-
-<script>
-function addrow0(racer) {
-  return add_table_row('#main_tbody', racer,
-                <?php echo $xbs ? json_encode($xbs_award_name) : "false"; ?>);
-}
-
-  <?php
-$n = 1;
-foreach ($stmt as $rs) {
-  // TODO
-  $rs['rankseq'] = $ranks[$rs['rankid']]['seq'];
-  if (is_null($rs['note'])) {
-    $rs['note'] = '';
-  }
-  echo "addrow0(".json_encode(json_table_row($rs, $n),
-                              JSON_NUMERIC_CHECK | JSON_UNESCAPED_SLASHES |
-                              JSON_HEX_AMP | JSON_HEX_TAG | JSON_HEX_APOS).");\n";
-  ++$n;
-}
-?>
-
-$(function () {
-var partitions = <?php echo json_encode($partitions,
-                                        JSON_NUMERIC_CHECK | JSON_UNESCAPED_SLASHES |
-                                        JSON_HEX_AMP | JSON_HEX_TAG | JSON_HEX_APOS); ?>;
-var partition_label_pl = <?php echo json_encode(partition_label_pl(),
-                                        JSON_NUMERIC_CHECK | JSON_UNESCAPED_SLASHES |
-                                        JSON_HEX_AMP | JSON_HEX_TAG | JSON_HEX_APOS); ?>;
-
-$("#edit_partition").empty();
-for (var i in partitions) {
-  var opt = $("<option/>")
-      .attr('value', partitions[i].partitionid)
-      .text(partitions[i].name);
-  opt.appendTo("#edit_partition");
-  opt.clone().appendTo("#bulk_who");
-}
-var opt = $("<option/>")
-    .attr('value', -1)
-.text("(Edit " + partition_label_pl + ")");
-opt.appendTo("#edit_partition");
-opt.clone().appendTo("#bulk_who");
-
-mobile_select_refresh($("#edit_partition"));
-mobile_select_refresh($("#bulk_who"));
-
-{
-  var reorder_modal = PartitionsModal(
-    "<?php echo htmlspecialchars(partition_label(), ENT_QUOTES, 'UTF-8'); ?>",
-    "<?php echo htmlspecialchars(partition_label_pl(), ENT_QUOTES, 'UTF-8'); ?>",
-    partitions, callback_after_partition_modal);
-
-  $("#edit_partition").on('change', function(ev) { on_edit_partition_change(ev.target, reorder_modal); });
-  $("#bulk_who").on('change', function(ev) { on_edit_partition_change(ev.target, reorder_modal); });
-}
-
-});
-</script>
-
-
-<div id='edit_racer_modal' class="modal_dialog hidden block_buttons">
-  <form id="editracerform">
-    <div id="left-edit">
-      <label for="edit_firstname">First name:</label>
-      <input id="edit_firstname" type="text" name="edit_firstname" value=""/>
-      <label for="edit_lastname">Last name:</label>
-      <input id="edit_lastname" type="text" name="edit_lastname" value=""/>
-
-      <label for="edit_carno">Car number:</label>
-      <input id="edit_carno" type="text" name="edit_carno" value=""/>
-
-      <label for="edit_carname">Car name:</label>
-      <input id="edit_carname" type="text" name="edit_carname" value=""/>
-    </div>
-
-    <div id="right-edit">
-      <label for="edit_partition">
-        <?php echo htmlspecialchars(partition_label().':', ENT_QUOTES, 'UTF-8'); ?>
-      </label>
-      <!-- Populated by javascript -->
-      <select id="edit_partition" data-wrapper-class="partition_mselect"></select>
-
-      <label for="edit_note_from">From (if desired):</label>
-      <input id="edit_note_from" type="text" name="edit_note_from" value=""/>
-
-      <label for="eligible">Trophy eligibility:</label>
-      <input type="checkbox" class="flipswitch" name="eligible" id="eligible"
-            data-wrapper-class="trophy-eligible-flipswitch"
-            data-off-text="Excluded"
-            data-on-text="Eligible"/>
-      <br/>
-
-      <input type="submit"/>
-      <input type="button" value="Cancel"
-        onclick='close_modal("#edit_racer_modal");'/>
-
-      <div id="delete_racer_extension">
-        <input type="button" value="Delete Racer"
-           class="delete_button"
-           onclick="handle_delete_racer();"/>
-      </div>
-    </div>
-
-  <input id="edit_racer" type="hidden" name="racer" value=""/>
-
-</form>
-</div>
-
-<div id='photo_modal' class="modal_dialog hidden block_buttons">
-  <form id="photo_drop" class="dropzone">
-    <input type="hidden" name="action" value="photo.upload"/>
-    <input type="hidden" id="photo_modal_repo" name="repo"/>
-    <input type="hidden" id="photo_modal_racerid" name="racerid"/>
-    <input type="hidden" name="MAX_FILE_SIZE" value="30000000" />
-
-    <h3>Capture <span id="racer_photo_repo"></span>
-        photo for <span id="racer_photo_name"></span>
-    </h3>
-
-    <video id="preview" autoplay="true" muted="true" playsinline="true"></video>
-
-    <div id="left-photo">
-
-    <?php
-      if (headshots()->status() != 'ok') {
-        echo '<p class="warning">Check <a href="settings.php">photo directory settings</a> before proceeding!</p>';
-      }
-    ?>
-
-    <div class="block_buttons">
-        <input type="submit" value="Capture &amp; Check In" id="capture_and_check_in"
-           onclick='g_check_in = true;'/>
-        <br/>
-        <input type="submit" value="Capture Only"
-          onclick='g_check_in = false;'/>
-        <input type="button" value="Cancel"
-          onclick='close_photo_modal();'/>
-    </div>
-    </div>
-    <div id="right-photo">
-        <select id="device-picker"></select>
-
-        <label id="autocrop-label" for="autocrop">Auto-crop after upload:</label>
-        <div class="centered_flipswitch">
-          <input type="checkbox" class="flipswitch" name="autocrop" id="autocrop" checked="checked"/>
-        </div>
-<div>
-      <a id="thumb-link" class="button_link">To Photo Page</a>
-</div>
-    </div>
-
-      <div class="dz-message"><span>NOTE: You can drop a photo here to upload instead</span></div>
-  </form>
-</div>
-
-
-<div id='bulk_modal' class="modal_dialog hidden block_buttons">
-  <input type="button" value="Bulk Check-In"
-    onclick="bulk_check_in(true);"/>
-  <input type="button" value="Bulk Check-In Undo"
-    onclick="bulk_check_in(false);"/>
-  <br/>
-  <input type="button" value="Bulk Renumbering"
-    onclick="bulk_numbering();"/>
-  <input type="button" value="Bulk Eligibility"
-    onclick="bulk_eligibility();"/>
-  <br/>
-  <input type="button" value="Cancel"
-    onclick='close_modal("#bulk_modal");'/>
-</div>
-
-<div id="bulk_details_modal" class="modal_dialog hidden block_buttons">
-    <form id="bulk_details">
-      <h2 id="bulk_details_title"></h2>
-
-      <label id="who_label" for="bulk_who">Assign car numbers to</label>
-      <select id="bulk_who">
-        <option value="all">All</option>
-        <!-- Replaced by javascript -->
-      </select>
-
-      <div id="numbering_controls" class="hidable">
-        <label for="number_auto">Numbering:</label>
-        <input id="number_auto" name="number_auto"
-               type="checkbox" class="flipswitch eligible-flip"
-               checked="checked"
-               data-wrapper-class="trophy-eligible-flipswitch"
-               data-off-text="Custom"
-               data-on-text="Standard"/>
-        <?php
-            list($car_numbering_mult, $car_numbering_smallest) = read_car_numbering_values();
-        ?>
-        <div id="numbering_start_div" style="display: none">
-          <label for="bulk_numbering_start">Custom numbering from:</label>
-          <input type="number" id="bulk_numbering_start" name="bulk_numbering_start"
-                                                            disabled="disabled"
-                 value="<?php echo $car_numbering_smallest; ?>"/>
-        </div>
-        <div id="bulk_numbering_explanation">
-           <p>Car numbers start at <?php echo $car_numbering_smallest; ?><?php
-              if ($car_numbering_mult != 0) { ?><br/>
-                  and the hundreds place increments for each <?php echo partition_label_lc(); ?>.
-              <?php }
-              else {
-                echo ".";
-              } ?>
-           </p>
-       </div>
-
-      </div>
-
-      <div id="elibility_controls" class="hidable">
-        <label for="bulk_eligible">Trophy eligibility:</label>
-        <input type="checkbox" class="flipswitch eligible-flip"
-               checked="checked"
-               name="bulk_eligible" id="bulk_eligible"
-               data-wrapper-class="trophy-eligible-flipswitch"
-               data-off-text="Excluded"
-               data-on-text="Eligible"/>
-      </div>
-    
-      <input type="submit"/>
-      <input type="button" value="Cancel"
-        onclick='pop_modal("#bulk_details_modal");'/>
-    </form>
-</div>
-
-
-<div id="barcode_settings_modal" class="modal_dialog hidden block_buttons">
-  <form>
-    <h2>Barcode Responses</h2>
-    <input id="barcode-handling-locate" name="barcode-handling" type="radio" value="locate"/>
-    <label for="barcode-handling-locate">Locate racer</label>
-    <input id="barcode-handling-checkin" name="barcode-handling" type="radio" value="checkin"/>
-    <label for="barcode-handling-checkin">Check in racer</label>
-    <input id="barcode-handling-racer" name="barcode-handling" type="radio" value="racer-photo"/>
-    <label for="barcode-handling-racer">Capture racer photo</label>
-    <input id="barcode-handling-car" name="barcode-handling" type="radio" value="car-photo"/>
-    <label for="barcode-handling-car">Capture car photo</label>
-
-    <input type="submit" value="Close"/>
-  </form>
-</div>
-
-<div id="qrcode_settings_modal" class="modal_dialog wide_modal hidden block_buttons">
-  <form id="mobile-checkin-form">
-    <h2>Mobile Check-In</h2>
-    <div id="mobile-checkin-qrcode" style="width: 256px; margin-left: 122px;"></div>
-    <div id="mobile-checkin-title" style="text-align: center; font-size: 1.5em; font-weight: bold; margin-bottom: 25px; margin-top: 10px;"></div>
-    <input id="mobile-checkin-url" name="mobile-checkin-url" type="text" />
-
-    <a id="mcheckin-link" class="button_link" href="mcheckin.php">Mobile Check-In &gt;</a>
-    <input type="button" value="Close" onclick="close_modal('#qrcode_settings_modal');"/>
-  </form>
-</div>
 
 <?php require_once('inc/ajax-pending.inc'); ?>
 

--- a/website/inc/checkin-table-data.inc
+++ b/website/inc/checkin-table-data.inc
@@ -1,0 +1,35 @@
+<?php
+
+function get_partitions() {
+    global $db;
+    $stmt = $db->query('SELECT partitionid, name,'
+        .'  (SELECT COUNT(*) FROM RegistrationInfo'
+        .'     WHERE RegistrationInfo.partitionid = Partitions.partitionid) AS count'
+        .' FROM Partitions'
+        .' ORDER BY sortorder');
+    $partitions = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    if (count($partitions) == 0) {
+        // 0 won't be used as a partitionid, but will cause the server to create a new
+        // partition with default name.
+        $partitions[] = array('partitionid' => 0,
+            'name' => DEFAULT_PARTITION_NAME);
+    }
+
+    return $partitions;
+}
+
+function get_racers($order)
+{
+    global $db;
+
+    $sql = checkin_table_SELECT_FROM_sql()
+        .' ORDER BY '
+        .($order == 'car' ? 'carnumber, lastname, firstname' :
+            ($order == 'class'  ? 'class_sort, rank_sort, lastname, firstname' :
+                ($order == 'partition' ? 'partition_sortorder, lastname, firstname' :
+                    'lastname, firstname')));
+
+    $stmt = $db->prepare($sql);
+    $stmt->execute(array(':xbs_award_name' => xbs_award()));
+    return $stmt;
+}

--- a/website/partials/checkin/barcode_settings_modal.php
+++ b/website/partials/checkin/barcode_settings_modal.php
@@ -1,0 +1,15 @@
+<div id="barcode_settings_modal" class="modal_dialog hidden block_buttons">
+    <form>
+        <h2>Barcode Responses</h2>
+        <input id="barcode-handling-locate" name="barcode-handling" type="radio" value="locate"/>
+        <label for="barcode-handling-locate">Locate racer</label>
+        <input id="barcode-handling-checkin" name="barcode-handling" type="radio" value="checkin"/>
+        <label for="barcode-handling-checkin">Check in racer</label>
+        <input id="barcode-handling-racer" name="barcode-handling" type="radio" value="racer-photo"/>
+        <label for="barcode-handling-racer">Capture racer photo</label>
+        <input id="barcode-handling-car" name="barcode-handling" type="radio" value="car-photo"/>
+        <label for="barcode-handling-car">Capture car photo</label>
+
+        <input type="submit" value="Close"/>
+    </form>
+</div>

--- a/website/partials/checkin/bulk_modal.php
+++ b/website/partials/checkin/bulk_modal.php
@@ -1,0 +1,14 @@
+<div id='bulk_modal' class="modal_dialog hidden block_buttons">
+    <input type="button" value="Bulk Check-In"
+           onclick="bulk_check_in(true);"/>
+    <input type="button" value="Bulk Check-In Undo"
+           onclick="bulk_check_in(false);"/>
+    <br/>
+    <input type="button" value="Bulk Renumbering"
+           onclick="bulk_numbering();"/>
+    <input type="button" value="Bulk Eligibility"
+           onclick="bulk_eligibility();"/>
+    <br/>
+    <input type="button" value="Cancel"
+           onclick='close_modal("#bulk_modal");'/>
+</div>

--- a/website/partials/checkin/bulk_renumbering_modal.php
+++ b/website/partials/checkin/bulk_renumbering_modal.php
@@ -1,0 +1,50 @@
+<div id="bulk_details_modal" class="modal_dialog hidden block_buttons">
+    <form id="bulk_details">
+        <h2 id="bulk_details_title"></h2>
+
+        <label id="who_label" for="bulk_who">Assign car numbers to</label>
+        <select id="bulk_who">
+            <option value="all">All</option>
+            <!-- Replaced by javascript -->
+        </select>
+
+        <div id="numbering_controls" class="hidable">
+            <label for="number_auto">Numbering:</label>
+            <input id="number_auto" name="number_auto"
+                   type="checkbox" class="flipswitch eligible-flip"
+                   checked="checked"
+                   data-wrapper-class="trophy-eligible-flipswitch"
+                   data-off-text="Custom"
+                   data-on-text="Standard"/>
+            <div id="numbering_start_div" style="display: none">
+                <label for="bulk_numbering_start">Custom numbering from:</label>
+                <input type="number" id="bulk_numbering_start" name="bulk_numbering_start"
+                       disabled="disabled"
+                       value="<?php echo $car_numbering_smallest; ?>"/>
+            </div>
+            <div id="bulk_numbering_explanation">
+                <p>Car numbers start at <?php echo $car_numbering_smallest; ?>
+                        <?php if ($car_numbering_mult != 0): ?><br/>
+                        and the hundreds place increments for each <?php echo $partition_label_lc; ?>.
+                        <?php else: ?>.
+                        <?php endif; ?>
+                </p>
+            </div>
+
+        </div>
+
+        <div id="elibility_controls" class="hidable">
+            <label for="bulk_eligible">Trophy eligibility:</label>
+            <input type="checkbox" class="flipswitch eligible-flip"
+                   checked="checked"
+                   name="bulk_eligible" id="bulk_eligible"
+                   data-wrapper-class="trophy-eligible-flipswitch"
+                   data-off-text="Excluded"
+                   data-on-text="Eligible"/>
+        </div>
+
+        <input type="submit"/>
+        <input type="button" value="Cancel"
+               onclick='pop_modal("#bulk_details_modal");'/>
+    </form>
+</div>

--- a/website/partials/checkin/edit_racer_modal.php
+++ b/website/partials/checkin/edit_racer_modal.php
@@ -1,0 +1,82 @@
+<div id='edit_racer_modal' class="modal_dialog hidden block_buttons">
+  <form id="editracerform">
+    <div id="left-edit">
+      <label for="edit_firstname">First name:</label>
+      <input id="edit_firstname" type="text" name="edit_firstname" value=""/>
+      <label for="edit_lastname">Last name:</label>
+      <input id="edit_lastname" type="text" name="edit_lastname" value=""/>
+
+      <label for="edit_carno">Car number:</label>
+      <input id="edit_carno" type="text" name="edit_carno" value=""/>
+
+      <label for="edit_carname">Car name:</label>
+      <input id="edit_carname" type="text" name="edit_carname" value=""/>
+    </div>
+
+    <div id="right-edit">
+      <label for="edit_partition">
+        <?php echo esc($partition_label.':'); ?>
+      </label>
+      <!-- Populated by javascript -->
+      <select id="edit_partition" data-wrapper-class="partition_mselect"></select>
+
+      <label for="edit_note_from">From (if desired):</label>
+      <input id="edit_note_from" type="text" name="edit_note_from" value=""/>
+
+      <label for="eligible">Trophy eligibility:</label>
+      <input type="checkbox" class="flipswitch" name="eligible" id="eligible"
+            data-wrapper-class="trophy-eligible-flipswitch"
+            data-off-text="Excluded"
+            data-on-text="Eligible"/>
+      <br/>
+
+      <input type="submit"/>
+      <input type="button" value="Cancel"
+        onclick='close_modal("#edit_racer_modal");'/>
+
+      <div id="delete_racer_extension">
+        <input type="button" value="Delete Racer"
+           class="delete_button"
+           onclick="handle_delete_racer();"/>
+      </div>
+    </div>
+
+  <input id="edit_racer" type="hidden" name="racer" value=""/>
+
+</form>
+</div>
+<script>
+    // Populate dropdown in modals with partition list
+    $(function () {
+        var partitions = <?php echo to_json($partitions); ?>;
+        var partition_label_pl = <?php echo to_json($partition_label_pl); ?>;
+
+        $("#edit_partition").empty();
+        for (var i in partitions) {
+            var opt = $("<option/>")
+                .attr('value', partitions[i].partitionid)
+                .text(partitions[i].name);
+            opt.appendTo("#edit_partition");
+            opt.clone().appendTo("#bulk_who");
+        }
+        var opt = $("<option/>")
+            .attr('value', -1)
+            .text("(Edit " + partition_label_pl + ")");
+        opt.appendTo("#edit_partition");
+        opt.clone().appendTo("#bulk_who");
+
+        mobile_select_refresh($("#edit_partition"));
+        mobile_select_refresh($("#bulk_who"));
+
+        {
+            var reorder_modal = PartitionsModal(
+                "<?php echo esc(partition_label()); ?>",
+                "<?php echo esc(partition_label_pl()); ?>",
+                partitions, callback_after_partition_modal);
+
+            $("#edit_partition").on('change', function(ev) { on_edit_partition_change(ev.target, reorder_modal); });
+            $("#bulk_who").on('change', function(ev) { on_edit_partition_change(ev.target, reorder_modal); });
+        }
+
+    });
+</script>

--- a/website/partials/checkin/main_checkin_table.php
+++ b/website/partials/checkin/main_checkin_table.php
@@ -1,0 +1,61 @@
+<?php
+// The table of racers can be presented in order by name, car, or class (and
+// then by name within the class).  Each sortable column has a header which is a
+// link to change the ordering, with the exception that the header for the
+// column for ordering currently in use is NOT a link (because it wouldn't do
+// anything).
+function column_header($text, $o) {
+  global $order;
+  return "<a data-order='".$o."' "
+      .($o == $order ? "" : " href='#'").">".$text."</a>";
+}
+?>
+<div id="main-checkin-table-div">
+    <table id="main-checkin-table" class="main_table">
+        <thead>
+        <tr>
+            <th/>
+            <th><?php echo column_header(esc($partition_label), 'partition'); ?></th>
+            <th><?php echo column_header('Car Number', 'car'); ?></th>
+            <th>Photo</th>
+            <th><?php echo column_header('Last Name', 'name'); ?></th>
+            <th>First Name</th>
+            <th>Car Name &amp; From</th>
+            <th>Passed?</th>
+            <?php if ($use_xbs):?>
+                <th><?php echo $xbs_award_name; ?></th>
+            <?php endif; ?>
+        </tr>
+        </thead>
+
+        <tbody id="main_tbody">
+
+        </tbody>
+    </table>
+</div>
+
+<script>
+    function set_checkin_table_height() {
+        $("#main-checkin-table-div").height(
+            $(window).height() - $(".banner").height() - $("#top-buttons").height());
+    }
+    $(function() { set_checkin_table_height(); });
+    $(window).on('resize', set_checkin_table_height);
+
+
+    function addrow0(racer) {
+        return add_table_row('#main_tbody', racer,
+            <?php echo $use_xbs ? json_encode($xbs_award_name) : "false"; ?>);
+    }
+
+    <?php
+    foreach ($racers as $n => $rs) {
+        // TODO
+        $rs['rankseq'] = $ranks[$rs['rankid']]['seq'];
+        if (is_null($rs['note'])) {
+            $rs['note'] = '';
+        }
+        echo "addrow0(".to_json(json_table_row($rs, $n + 1)).");\n";
+    }
+    ?>
+</script>

--- a/website/partials/checkin/photo_modal.php
+++ b/website/partials/checkin/photo_modal.php
@@ -1,0 +1,43 @@
+<div id='photo_modal' class="modal_dialog hidden block_buttons">
+    <form id="photo_drop" class="dropzone">
+        <input type="hidden" name="action" value="photo.upload"/>
+        <input type="hidden" id="photo_modal_repo" name="repo"/>
+        <input type="hidden" id="photo_modal_racerid" name="racerid"/>
+        <input type="hidden" name="MAX_FILE_SIZE" value="30000000" />
+
+        <h3>Capture <span id="racer_photo_repo"></span>
+            photo for <span id="racer_photo_name"></span>
+        </h3>
+
+        <video id="preview" autoplay="true" muted="true" playsinline="true"></video>
+
+        <div id="left-photo">
+
+            <?php if ($showSettingsWarning) :?>
+                <p class="warning">Check <a href="settings.php">photo directory settings</a> before proceeding!</p>
+            <?php endif; ?>
+            <div class="block_buttons">
+                <input type="submit" value="Capture &amp; Check In" id="capture_and_check_in"
+                       onclick='g_check_in = true;'/>
+                <br/>
+                <input type="submit" value="Capture Only"
+                       onclick='g_check_in = false;'/>
+                <input type="button" value="Cancel"
+                       onclick='close_photo_modal();'/>
+            </div>
+        </div>
+        <div id="right-photo">
+            <select id="device-picker"></select>
+
+            <label id="autocrop-label" for="autocrop">Auto-crop after upload:</label>
+            <div class="centered_flipswitch">
+                <input type="checkbox" class="flipswitch" name="autocrop" id="autocrop" checked="checked"/>
+            </div>
+            <div>
+                <a id="thumb-link" class="button_link">To Photo Page</a>
+            </div>
+        </div>
+
+        <div class="dz-message"><span>NOTE: You can drop a photo here to upload instead</span></div>
+    </form>
+</div>

--- a/website/partials/checkin/qrcode_settings_modal.php
+++ b/website/partials/checkin/qrcode_settings_modal.php
@@ -1,0 +1,11 @@
+<div id="qrcode_settings_modal" class="modal_dialog wide_modal hidden block_buttons">
+    <form id="mobile-checkin-form">
+        <h2>Mobile Check-In</h2>
+        <div id="mobile-checkin-qrcode" style="width: 256px; margin-left: 122px;"></div>
+        <div id="mobile-checkin-title" style="text-align: center; font-size: 1.5em; font-weight: bold; margin-bottom: 25px; margin-top: 10px;"></div>
+        <input id="mobile-checkin-url" name="mobile-checkin-url" type="text" />
+
+        <a id="mcheckin-link" class="button_link" href="mcheckin.php">Mobile Check-In &gt;</a>
+        <input type="button" value="Close" onclick="close_modal('#qrcode_settings_modal');"/>
+    </form>
+</div>

--- a/website/partials/checkin/top_buttons.php
+++ b/website/partials/checkin/top_buttons.php
@@ -1,0 +1,15 @@
+<div id="top-buttons" class="block_buttons">
+    <img id="barcode-button" src="img/barcode.png"
+         onclick="handle_barcode_button_click()"/>
+    <input id="mobile-button" type="button" value="Mobile"
+           onclick="handle_qrcode_button_click()"/>
+    <input class="bulk_button"
+           type="button" value="Bulk"
+           onclick='show_bulk_form();'/>
+    <?php if ($include_new_racer_button): ?>
+        <input type="button" value="New Racer"
+               onclick='show_new_racer_form();'/>
+    <?php else: ?>
+        <div style='padding: 10px 15px; font-size: x-large; line-height: 1.3; margin-bottom: 20px; margin-top: 3px; '>&nbsp;</div>
+    <?php endif; ?>
+</div>

--- a/website/partials/partials_helper.inc
+++ b/website/partials/partials_helper.inc
@@ -1,0 +1,17 @@
+<?php
+function include_partial(string $path, array $vars = []): string
+{
+    if (!file_exists($path)) {
+        throw new RuntimeException("Partial not found: $path");
+    }
+
+    extract($vars, EXTR_SKIP);
+
+    ob_start();
+    include $path;
+    return ob_get_clean();
+}
+function esc(string $string): string
+{
+    return htmlspecialchars($string, ENT_QUOTES, 'UTF-8');
+}


### PR DESCRIPTION
I’m interested in contributing to Derbynet and have been spending some time getting familiar with the codebase. Coming from a framework-oriented PHP background (mostly Symfony), I’ve found it a bit challenging to navigate pages where markup, business logic, and data handling are intermixed.

This PR is a small experiment in improving separation of concerns while staying firmly in Derbynet’s existing “plain PHP” approach.

Specifically, it refactors the check-in page to extract several UI sections into small PHP partial templates.

Each partial:
* receives only the data explicitly passed to it
* is responsible only for rendering markup
* includes any bits of JavaScript that are tightly coupled to that UI component

Examples:
* `main_checkin_table.php` receives the list of racers, and a few other data points: https://github.com/mkopinsky/derbynet/blob/01f70aed7b7438e35c199df2310b27c854c63d01/website/checkin.php#L101-L107
* `barcode_settings_modal.php` doesn't include anything dynamic so the call to `include_partial` doesn't need to pass any parameters: https://github.com/mkopinsky/derbynet/blob/01f70aed7b7438e35c199df2310b27c854c63d01/website/checkin.php#L130

The page logic remains in checkin.php, which effectively acts as the controller. Permission checks, data loading, and other business logic stay there, while the partials focus purely on presentation.

The goal is to make the page structure easier to navigate and modify without introducing any framework or new dependencies.

If this approach seems useful, I’d be happy to continue applying the same pattern to other pages. If not, no worries at all - just thought this might be a helpful direction.